### PR TITLE
Ignore AS32590

### DIFF
--- a/ignore-asns.txt
+++ b/ignore-asns.txt
@@ -6,6 +6,7 @@
 18403   FPT-AS-AP
 19174   China Unicom (Americas) Operations Ltd
 19690   Hyatt Corporation
+32590   Valve Corporation
 36408   CDNetworks Inc.
 38001   NewMedia Express Pte Ltd
 38248   VTC-VN


### PR DESCRIPTION
`103.10.124.0/24` is currently part of chnroutes2 but it's actually located in Singapore. AS32590 doesn't seem to have any Chinese node so we should ignore this AS.